### PR TITLE
feat(solidr-program): add_session_member implementation

### DIFF
--- a/packages/programs/solidr-program/Anchor.toml
+++ b/packages/programs/solidr-program/Anchor.toml
@@ -19,7 +19,7 @@ cluster = "localnet"
 wallet = "/opt/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.spec.ts"
 
 [workspace]
 types = "client/types/"

--- a/packages/programs/solidr-program/client/types/solidr.ts
+++ b/packages/programs/solidr-program/client/types/solidr.ts
@@ -14,11 +14,64 @@ export type Solidr = {
     };
     instructions: [
         {
+            name: 'addSessionMember';
+            docs: [
+                '* Session administrator can add members.\n     *\n     * @dev members can be added only by session administrator when session is opened\n     * An event MemberAdded is emitted\n     *\n     * @param addr The address of the member to add\n     * @param name The nickname of the member to add',
+            ];
+            discriminator: [182, 216, 208, 245, 11, 232, 215, 63];
+            accounts: [
+                {
+                    name: 'admin';
+                    writable: true;
+                    signer: true;
+                },
+                {
+                    name: 'session';
+                    writable: true;
+                },
+                {
+                    name: 'member';
+                    writable: true;
+                    pda: {
+                        seeds: [
+                            {
+                                kind: 'const';
+                                value: [109, 101, 109, 98, 101, 114];
+                            },
+                            {
+                                kind: 'account';
+                                path: 'session.session_id';
+                                account: 'sessionAccount';
+                            },
+                            {
+                                kind: 'arg';
+                                path: 'addr';
+                            },
+                        ];
+                    };
+                },
+                {
+                    name: 'systemProgram';
+                    address: '11111111111111111111111111111111';
+                },
+            ];
+            args: [
+                {
+                    name: 'addr';
+                    type: 'pubkey';
+                },
+                {
+                    name: 'name';
+                    type: 'string';
+                },
+            ];
+        },
+        {
             name: 'initGlobal';
             discriminator: [44, 238, 77, 253, 76, 182, 192, 162];
             accounts: [
                 {
-                    name: 'globalAccount';
+                    name: 'global';
                     writable: true;
                     pda: {
                         seeds: [
@@ -97,11 +150,19 @@ export type Solidr = {
             discriminator: [129, 105, 124, 171, 189, 42, 108, 69];
         },
         {
+            name: 'memberAccount';
+            discriminator: [173, 25, 100, 97, 192, 177, 84, 139];
+        },
+        {
             name: 'sessionAccount';
             discriminator: [74, 34, 65, 133, 96, 163, 80, 69];
         },
     ];
     events: [
+        {
+            name: 'memberAdded';
+            discriminator: [198, 220, 228, 196, 92, 235, 240, 79];
+        },
         {
             name: 'sessionClosed';
             discriminator: [57, 237, 11, 243, 194, 34, 120, 27];
@@ -122,6 +183,21 @@ export type Solidr = {
             name: 'sessionDescriptionTooLong';
             msg: "Session's description can't exceed 80 characters";
         },
+        {
+            code: 6002;
+            name: 'forbiddenAsNonAdmin';
+            msg: 'Only session administrator is granted';
+        },
+        {
+            code: 6003;
+            name: 'sessionClosed';
+            msg: 'Session is closed';
+        },
+        {
+            code: 6004;
+            name: 'memberAlreadyExists';
+            msg: 'Member already exists';
+        },
     ];
     types: [
         {
@@ -132,6 +208,46 @@ export type Solidr = {
                     {
                         name: 'sessionCount';
                         type: 'u64';
+                    },
+                ];
+            };
+        },
+        {
+            name: 'memberAccount';
+            type: {
+                kind: 'struct';
+                fields: [
+                    {
+                        name: 'sessionId';
+                        type: 'u64';
+                    },
+                    {
+                        name: 'addr';
+                        type: 'pubkey';
+                    },
+                    {
+                        name: 'name';
+                        type: 'string';
+                    },
+                ];
+            };
+        },
+        {
+            name: 'memberAdded';
+            type: {
+                kind: 'struct';
+                fields: [
+                    {
+                        name: 'sessionId';
+                        type: 'u64';
+                    },
+                    {
+                        name: 'addr';
+                        type: 'pubkey';
+                    },
+                    {
+                        name: 'name';
+                        type: 'string';
                     },
                 ];
             };
@@ -156,10 +272,6 @@ export type Solidr = {
                     {
                         name: 'admin';
                         type: 'pubkey';
-                    },
-                    {
-                        name: 'membersCount';
-                        type: 'u8';
                     },
                     {
                         name: 'expensesCount';

--- a/packages/programs/solidr-program/programs/solidr-program/src/errors.rs
+++ b/packages/programs/solidr-program/programs/solidr-program/src/errors.rs
@@ -6,4 +6,10 @@ pub enum SolidrError {
     SessionNameTooLong,
     #[msg("Session's description can't exceed 80 characters")]
     SessionDescriptionTooLong,
+    #[msg("Only session administrator is granted")]
+    ForbiddenAsNonAdmin,
+    #[msg("Session is closed")]
+    SessionClosed,
+    #[msg("Member already exists")]
+    MemberAlreadyExists,
 }

--- a/packages/programs/solidr-program/programs/solidr-program/src/instructions/members.rs
+++ b/packages/programs/solidr-program/programs/solidr-program/src/instructions/members.rs
@@ -1,0 +1,65 @@
+use anchor_lang::prelude::*;
+
+use crate::errors::*;
+use crate::state::members::*;
+use crate::state::sessions::*;
+
+#[derive(Accounts)]
+#[instruction(addr: Pubkey)]
+pub struct AddSessionMemberContextData<'info> {
+    #[account(mut)]
+    pub admin: Signer<'info>,
+
+    #[account(mut)]
+    pub session: Account<'info, SessionAccount>,
+
+    #[account(
+        init_if_needed,
+        payer = admin,
+        space = 8 + MemberAccount::INIT_SPACE,
+        seeds = [
+            MemberAccount::SEED_PREFIX,
+            session.session_id.to_le_bytes().as_ref(),
+            addr.key().as_ref(),
+        ],
+        bump
+    )]
+    pub member: Account<'info, MemberAccount>,
+
+    pub system_program: Program<'info, System>,
+}
+
+pub fn add_session_member(
+    ctx: Context<AddSessionMemberContextData>,
+    addr: Pubkey,
+    name: String,
+) -> Result<()> {
+    let session = &mut ctx.accounts.session;
+    let member = &mut ctx.accounts.member;
+
+    require!(
+        session.admin.key() == ctx.accounts.admin.key(),
+        SolidrError::ForbiddenAsNonAdmin
+    );
+
+    require!(
+        session.status == SessionStatus::Opened,
+        SolidrError::SessionClosed
+    );
+
+    require!(
+        member.addr.key() != addr.key(),
+        SolidrError::MemberAlreadyExists
+    );
+
+    member.session_id = session.session_id;
+    member.name = name.clone();
+    member.addr = addr.key();
+
+    emit!(MemberAdded {
+        session_id: member.session_id,
+        addr: addr.key(),
+        name,
+    });
+    Ok(())
+}

--- a/packages/programs/solidr-program/programs/solidr-program/src/instructions/mod.rs
+++ b/packages/programs/solidr-program/programs/solidr-program/src/instructions/mod.rs
@@ -1,2 +1,3 @@
 pub mod global;
 pub mod sessions;
+pub mod members;

--- a/packages/programs/solidr-program/programs/solidr-program/src/instructions/sessions.rs
+++ b/packages/programs/solidr-program/programs/solidr-program/src/instructions/sessions.rs
@@ -48,7 +48,6 @@ pub fn open_session(
     session.description = description.clone();
     session.status = SessionStatus::Opened;
     session.expenses_count = 0;
-    session.members_count = 0;
 
     global.session_count += 1;
 

--- a/packages/programs/solidr-program/programs/solidr-program/src/lib.rs
+++ b/packages/programs/solidr-program/programs/solidr-program/src/lib.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::instructions::{global::*, sessions::*};
+use crate::instructions::{global::*, members::*, sessions::*};
 
 pub mod errors;
 pub mod instructions;
@@ -33,5 +33,22 @@ pub mod solidr {
         description: String,
     ) -> Result<()> {
         sessions::open_session(ctx, name, description)
+    }
+
+    /**
+     * Session administrator can add members.
+     *
+     * @dev members can be added only by session administrator when session is opened
+     * An event MemberAdded is emitted
+     *
+     * @param addr The address of the member to add
+     * @param name The nickname of the member to add
+     */
+    pub fn add_session_member(
+        ctx: Context<AddSessionMemberContextData>,
+        addr: Pubkey,
+        name: String,
+    ) -> Result<()> {
+        members::add_session_member(ctx, addr, name)
     }
 }

--- a/packages/programs/solidr-program/programs/solidr-program/src/state/members.rs
+++ b/packages/programs/solidr-program/programs/solidr-program/src/state/members.rs
@@ -1,0 +1,21 @@
+use anchor_lang::prelude::*;
+
+#[account]
+#[derive(InitSpace)]
+pub struct MemberAccount {
+    pub session_id: u64, // 32
+    pub addr: Pubkey,    // 32
+    #[max_len(40)]
+    pub name: String, // 4 + 40
+}
+
+impl MemberAccount {
+    pub const SEED_PREFIX: &'static [u8; 6] = b"member";
+}
+
+#[event]
+pub struct MemberAdded {
+    pub session_id: u64,
+    pub addr: Pubkey,
+    pub name: String,
+}

--- a/packages/programs/solidr-program/programs/solidr-program/src/state/mod.rs
+++ b/packages/programs/solidr-program/programs/solidr-program/src/state/mod.rs
@@ -1,2 +1,3 @@
 pub mod global;
+pub mod members;
 pub mod sessions;

--- a/packages/programs/solidr-program/programs/solidr-program/src/state/sessions.rs
+++ b/packages/programs/solidr-program/programs/solidr-program/src/state/sessions.rs
@@ -10,7 +10,6 @@ pub struct SessionAccount {
     #[max_len(80)]
     pub description: String, // 4 + 80
     pub admin: Pubkey,   // 32
-    pub members_count: u8, // 1
     pub expenses_count: u16, // 2
     pub status: SessionStatus, // 1
 }


### PR DESCRIPTION
@nada-r @ncoquelet

#7

Cette MR permet a l'administrateur d'une session d'ajouter un nouveau membre en renseignant son adresse publique (pubkey) ainsi que son nom. C'est un peu geeky d'un point de vue UX...

J'ai aussi pensé a une autre méthode `join_session_as_member` qui permettrait a un utilisateur de joindre directement une session (dont il aurait eu le lien par n'importe quel moyen), mais ca pose la question d'une éventuelle validation par l'administrateur. A discuter donc...

Suite à nos différents échanges sur le sujet, j'ai enlevé members_counter de la session, et mis les propriétés `name` et `addr` dans le pda member.

`addr`fait également partie de la seed de ce pda.

J'aurais aimé de pas mettre `addr` dans la data du pda, puisque déja présent dans la seed, mais je crains qu'on ne puisse pas récupérer les éléments d'une seed quand on fait du listing (que ce soit avec la méthode `all` ou `getProgramAccounts`).
